### PR TITLE
fix: allow long annotations

### DIFF
--- a/internal/kube/labels.go
+++ b/internal/kube/labels.go
@@ -59,7 +59,7 @@ func NormalizeMetadata(obj *metav1.ObjectMeta) {
 
 	annots := make(map[string]string)
 	for k, v := range obj.Annotations {
-		annots[ToLabelKey(k)] = trimMiddle(v, 63)
+		annots[ToLabelKey(k)] = v
 	}
 	obj.Annotations = annots
 

--- a/internal/kube/labels_test.go
+++ b/internal/kube/labels_test.go
@@ -86,7 +86,7 @@ func TestNormalizeMetadata(t *testing.T) {
 	obj := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        strings.Repeat(" name ", 500),
-			Annotations: map[string]string{strings.Repeat("annot-key", 500): strings.Repeat("value", 500), "cloud.google.com/neg": `{"ingress": true}`},
+			Annotations: map[string]string{strings.Repeat("annot-key", 500): strings.Repeat("value", 500), "cloud.google.com/neg": `{"ingress": true}`, "long-value": strings.Repeat("value", 500)},
 			Labels:      map[string]string{strings.Repeat("label-key", 500): strings.Repeat("value", 500)},
 		},
 	}
@@ -95,4 +95,5 @@ func TestNormalizeMetadata(t *testing.T) {
 
 	test.RequireValidMetadata(t, obj)
 	require.Equal(t, `{"ingress": true}`, obj.Annotations["cloud.google.com/neg"])
+	require.Equal(t, strings.Repeat("value", 500), obj.Annotations["long-value"])
 }

--- a/internal/test/metadata.go
+++ b/internal/test/metadata.go
@@ -16,8 +16,7 @@ func RequireValidMetadata(t *testing.T, obj client.Object) {
 		require.LessOrEqual(t, len(k), 63)
 		require.LessOrEqual(t, len(v), 63, k)
 	}
-	for k, v := range obj.GetAnnotations() {
+	for k, _ := range obj.GetAnnotations() {
 		require.LessOrEqual(t, len(k), 63)
-		require.LessOrEqual(t, len(v), 63, k)
 	}
 }


### PR DESCRIPTION
# Problem

With the following `podTemplate`:

```
podTemplate:
  metadata:
    annotations:
      ad.datadoghq.com/node.checks: |
        {
          "openmetrics": {
            "init_config": {},
            "instances": [
              {
                "histogram_buckets_as_distributions": true,
                "collect_counters_with_distributions": false,
                "openmetrics_endpoint": "http://%%host%%:26660/metrics",
                "namespace": "chain",
                "metrics": [
                  "cometbft_consensus_height",
                  "cometbft_p2p_peers",
                  "cometbft_consensus_step_duration_seconds",
                  "cometbft_state_block_processing_time",
                  "go_gc_duration_seconds"
                ]
              }
            ]
          }
        }
```

A pod is produced like so:

```
apiVersion: v1
kind: Pod
metadata:
  annotations:
    ad.datadoghq.com/node.checks: |
      {
        "openmetrics": {
          "init_"
              ]
            }
          ]
        }
      }
```

# Solution

Removing the trimming functionality related to annotations. Based on the [k8s docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) It seems like annotation values are limited in length at all.
